### PR TITLE
Add post management commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.env

--- a/bot/bot.js
+++ b/bot/bot.js
@@ -1,14 +1,12 @@
 // bot/bot.js
-const TelegramBot = require('node-telegram-bot-api');
-const { BOT_TOKEN } = require('../config');
-const registerCommands = require('./handlers/messageHandler');
+import TelegramBot from 'node-telegram-bot-api';
+import { BOT_TOKEN } from '../config/index.js';
+import registerCommands from './handlers/messageHandler.js';
 
 let bot;
 
-const initBot = () => {
+export function initBot() {
   bot = new TelegramBot(BOT_TOKEN, { polling: true });
   console.log('🤖 TeleDraft bot started...');
   registerCommands(bot);
-};
-
-module.exports = { initBot };
+}

--- a/bot/commands/deletePost.js
+++ b/bot/commands/deletePost.js
@@ -1,0 +1,26 @@
+// bot/commands/deletePost.js
+import { deletePost as removePost, getPost } from '../../db/lowdb.js';
+
+export default function deletePost(bot) {
+  bot.onText(/\/deletepost/, (msg) => {
+    const chatId = msg.chat.id;
+    bot.sendMessage(chatId, '🗑 Send the name of the post to delete:');
+
+    bot.once('message', async (nameMsg) => {
+      const name = nameMsg.text.trim();
+
+      if (!name || name.startsWith('/')) {
+        return bot.sendMessage(chatId, '❌ Invalid name.');
+      }
+
+      const exists = await getPost(name);
+      if (!exists) {
+        return bot.sendMessage(chatId, `❌ Post *${name}* not found.`, { parse_mode: 'Markdown' });
+      }
+
+      await removePost(name);
+      bot.sendMessage(chatId, `✅ Post *${name}* deleted.`, { parse_mode: 'Markdown' });
+    });
+  });
+}
+

--- a/bot/commands/listPosts.js
+++ b/bot/commands/listPosts.js
@@ -1,0 +1,18 @@
+// bot/commands/listPosts.js
+import { getPosts } from '../../db/lowdb.js';
+
+export default function listPosts(bot) {
+  bot.onText(/\/listposts/, async (msg) => {
+    const chatId = msg.chat.id;
+    const posts = await getPosts();
+    const names = Object.keys(posts);
+
+    if (names.length === 0) {
+      return bot.sendMessage(chatId, 'ℹ️ No saved posts.');
+    }
+
+    const message = names.map((n, i) => `${i + 1}. ${n}`).join('\n');
+    bot.sendMessage(chatId, `📋 Saved posts:\n${message}`);
+  });
+}
+

--- a/bot/commands/sendPost.js
+++ b/bot/commands/sendPost.js
@@ -1,0 +1,26 @@
+// bot/commands/sendPost.js
+import { getPost } from '../../db/lowdb.js';
+import formatPost from '../../utils/formatPost.js';
+
+export default function sendPost(bot) {
+  bot.onText(/\/sendpost/, (msg) => {
+    const chatId = msg.chat.id;
+    bot.sendMessage(chatId, '📌 Send the name of the post:');
+
+    bot.once('message', async (nameMsg) => {
+      const name = nameMsg.text.trim();
+
+      if (!name || name.startsWith('/')) {
+        return bot.sendMessage(chatId, '❌ Invalid name.');
+      }
+
+      const content = await getPost(name);
+      if (!content) {
+        return bot.sendMessage(chatId, `❌ Post *${name}* not found.`, { parse_mode: 'Markdown' });
+      }
+
+      bot.sendMessage(chatId, formatPost(content), { parse_mode: 'Markdown' });
+    });
+  });
+}
+

--- a/bot/handlers/messageHandler.js
+++ b/bot/handlers/messageHandler.js
@@ -1,10 +1,12 @@
 // bot/handlers/messageHandler.js
-const newPost = require('../commands/newPost');
-const listPosts = require('../commands/listPosts');
-const sendPost = require('../commands/sendPost');
+import newPost from '../commands/newPost.js';
+import listPosts from '../commands/listPosts.js';
+import sendPost from '../commands/sendPost.js';
+import deletePost from '../commands/deletePost.js';
 
-module.exports = function registerCommands(bot) {
+export default function registerCommands(bot) {
   newPost(bot);
   listPosts(bot);
   sendPost(bot);
-};
+  deletePost(bot);
+}

--- a/config/index.js
+++ b/config/index.js
@@ -1,6 +1,4 @@
 // config/index.js
-require('dotenv').config();
+import 'dotenv/config';
 
-module.exports = {
-  BOT_TOKEN: process.env.BOT_TOKEN,
-};
+export const BOT_TOKEN = process.env.BOT_TOKEN;

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 // index.js
-require('dotenv').config();
-const { initBot } = require('./bot/bot');
+import 'dotenv/config';
+import { initBot } from './bot/bot.js';
 
 // Start the bot
 initBot();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "teledraft",
   "version": "1.0.0",
+  "type": "module",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/utils/formatPost.js
+++ b/utils/formatPost.js
@@ -1,0 +1,9 @@
+// utils/formatPost.js
+
+const emojis = ['😀', '🎉', '🔥', '😎', '✨'];
+
+export default function formatPost(content) {
+  const emoji = emojis[Math.floor(Math.random() * emojis.length)];
+  return `${content}\n\n${emoji}`;
+}
+


### PR DESCRIPTION
## Summary
- migrate project to ESM and enable module mode
- implement commands to list, send and delete posts
- add random-emoji post formatter
- load config/token via ES modules
- ignore environment file

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686c19da89c4832193e4ed4580952a05