### PR TITLE
Fix module exports and default database initialization

### DIFF
--- a/bot/commands/newPost.js
+++ b/bot/commands/newPost.js
@@ -1,7 +1,7 @@
 // bot/commands/newPost.js
-import { setPost } from '../../db/lowdb.js';
+const { setPost } = require('../../db/lowdb');
 
-export default function newPost(bot) {
+module.exports = function newPost(bot) {
   bot.onText(/\/newpost/, async (msg) => {
     const chatId = msg.chat.id;
 

--- a/db/lowdb.js
+++ b/db/lowdb.js
@@ -1,11 +1,11 @@
 // db/lowdb.js
-import { Low } from 'lowdb'
-import { JSONFile } from 'lowdb/node'
-import path from 'path'
+const { Low } = require('lowdb');
+const { JSONFile } = require('lowdb/node');
+const path = require('path');
 
 const file = path.resolve('./db/posts.json')
 const adapter = new JSONFile(file)
-const db = new Low(adapter)
+const db = new Low(adapter, { posts: {} })
 
 async function initDB() {
   await db.read()
@@ -17,24 +17,31 @@ async function initDB() {
   }
 }
 
-export async function setPost(name, content) {
+async function setPost(name, content) {
   await initDB()
   db.data.posts[name] = content
   await db.write()
 }
 
-export async function getPosts() {
+async function getPosts() {
   await initDB()
   return db.data.posts
 }
 
-export async function getPost(name) {
+async function getPost(name) {
   await initDB()
   return db.data.posts[name]
 }
 
-export async function deletePost(name) {
+async function deletePost(name) {
   await initDB()
   delete db.data.posts[name]
   await db.write()
 }
+
+module.exports = {
+  setPost,
+  getPosts,
+  getPost,
+  deletePost,
+};


### PR DESCRIPTION
## Summary
- use CommonJS exports for bot command `newPost`
- convert database helper to CommonJS and supply default data to lowdb

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686c1976a21c8321b7c86852b7383d86